### PR TITLE
[FIX] HTTP 환경에서 refresh token 쿠키 SameSite 설정 오류 수정

### DIFF
--- a/src/main/java/com/gorogoro/auth/authorization/adapter/in/web/AuthorizationController.java
+++ b/src/main/java/com/gorogoro/auth/authorization/adapter/in/web/AuthorizationController.java
@@ -36,7 +36,7 @@ public class AuthorizationController {
                 .secure(false)
                 .path("/")
                 .maxAge(JwtConstants.REFRESH_TOKEN_EXPIRATION_MILLIS / 1000)
-                .sameSite("None")
+                .sameSite("Lax")
                 .build();
 
         return ResponseEntity.ok()


### PR DESCRIPTION
<!-- PR 제목 : [HOTFIX] HTTP 개발 환경에서 refresh token 쿠키 저장 오류 수정 -->

## ✨ 요약
HTTP 개발 환경에서 `refresh_token` 쿠키가 저장되지 않던 문제를 해결했습니다.
`SameSite=None` 설정을 제거하고, 브라우저 정책에 맞게 `SameSite=Lax`로 변경하여 쿠키가 정상적으로 동작하도록 수정했습니다.


## 📝 작업 내용
- refresh token 쿠키 설정 수정
    - `SameSite=None` → `SameSite=Lax`
    - `Secure=false` 유지 (HTTP 개발 환경)
- HTTP 환경에서 브라우저가 쿠키를 거절하던 설정 조합 제거


## 💭 주의 사항
- 본 수정은 **HTTP 개발 환경 기준**입니다.
- 운영 환경(HTTPS)에서 프론트/백엔드 도메인이 분리된 경우
    `SameSite=None + Secure=true` 설정이 필요할 수 있습니다.
- 운영 반영 전 환경별 설정 분기 작업이 필요합니다.

---

## 💡 리뷰 포인트
- HTTP 개발 환경에서 `SameSite=Lax` 설정이 적절한지
- 추후 운영 환경 대응을 위한 설정 분기 위치가 적절한지