### PR TITLE
[FEAT] 유저 ID 목록 기반 닉네임 일괄 조회 API 구현

### DIFF
--- a/src/main/java/com/gorogoro/auth/user/adapter/in/server/ServerController.java
+++ b/src/main/java/com/gorogoro/auth/user/adapter/in/server/ServerController.java
@@ -9,6 +9,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+import java.util.Map;
+
 @RestController
 @RequestMapping("/server/users")
 @RequiredArgsConstructor
@@ -18,6 +21,11 @@ public class ServerController {
     @GetMapping("/nickname")
     public ResponseEntity<UserNicknameResponse> getUser(@RequestParam Long userId) {
         return ResponseEntity.ok(UserNicknameResponse.from(getUserUseCase.getUser(userId)));
+    }
+
+    @GetMapping("/nicknames")
+    public ResponseEntity<Map<Long, String>> getUserNicknames(@RequestParam List<Long> userIds) {
+        return ResponseEntity.ok(getUserUseCase.getUserNicknames(userIds));
     }
 }
 

--- a/src/main/java/com/gorogoro/auth/user/adapter/in/server/ServerController.java
+++ b/src/main/java/com/gorogoro/auth/user/adapter/in/server/ServerController.java
@@ -1,6 +1,7 @@
 package com.gorogoro.auth.user.adapter.in.server;
 
 import com.gorogoro.auth.user.adapter.in.server.response.UserNicknameResponse;
+import com.gorogoro.auth.user.adapter.in.server.response.UserNicknamesResponse;
 import com.gorogoro.auth.user.application.port.in.GetUserUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -10,7 +11,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
-import java.util.Map;
 
 @RestController
 @RequestMapping("/server/users")
@@ -24,8 +24,8 @@ public class ServerController {
     }
 
     @GetMapping("/nicknames")
-    public ResponseEntity<Map<Long, String>> getUserNicknames(@RequestParam List<Long> userIds) {
-        return ResponseEntity.ok(getUserUseCase.getUserNicknames(userIds));
+    public ResponseEntity<UserNicknamesResponse> getUserNicknames(@RequestParam List<Long> userIds) {
+        return ResponseEntity.ok(UserNicknamesResponse.from(getUserUseCase.getUserNicknames(userIds)));
     }
 }
 

--- a/src/main/java/com/gorogoro/auth/user/adapter/in/server/response/UserNicknamesResponse.java
+++ b/src/main/java/com/gorogoro/auth/user/adapter/in/server/response/UserNicknamesResponse.java
@@ -1,0 +1,25 @@
+package com.gorogoro.auth.user.adapter.in.server.response;
+
+import com.gorogoro.auth.user.application.dto.result.UserNicknamesResult;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class UserNicknamesResponse {
+    private Map<Long, String> nicknames;
+    private List<Long> missingUserIds;
+
+    public static UserNicknamesResponse from(UserNicknamesResult result) {
+        return UserNicknamesResponse.builder()
+                .nicknames(result.getNicknames())
+                .missingUserIds(result.getMissingUserIds())
+                .build();
+    }
+}

--- a/src/main/java/com/gorogoro/auth/user/adapter/out/persistence/adapter/UserPersistenceAdapter.java
+++ b/src/main/java/com/gorogoro/auth/user/adapter/out/persistence/adapter/UserPersistenceAdapter.java
@@ -9,6 +9,7 @@ import com.gorogoro.auth.user.domain.model.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.Optional;
 
 @Component
@@ -34,6 +35,13 @@ public class UserPersistenceAdapter implements UserQueryPort, UserCommandPort {
     public Optional<User> getUserId(Long userId) {
         return userJpaRepository.findById(userId)
                 .map(userMapper::toDomain);
+    }
+
+    @Override
+    public List<User> getUsersByIds(List<Long> ids) {
+        return userJpaRepository.findAllById(ids).stream()
+                .map(userMapper::toDomain)
+                .toList();
     }
 
     @Override

--- a/src/main/java/com/gorogoro/auth/user/application/dto/result/UserNicknamesResult.java
+++ b/src/main/java/com/gorogoro/auth/user/application/dto/result/UserNicknamesResult.java
@@ -1,0 +1,21 @@
+package com.gorogoro.auth.user.application.dto.result;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@Builder
+public class UserNicknamesResult {
+    private Map<Long, String> nicknames;
+    private List<Long> missingUserIds;
+
+    public static UserNicknamesResult of(Map<Long, String> nicknames, List<Long> missingUserIds) {
+        return UserNicknamesResult.builder()
+                .nicknames(nicknames)
+                .missingUserIds(missingUserIds)
+                .build();
+    }
+}

--- a/src/main/java/com/gorogoro/auth/user/application/port/in/GetUserUseCase.java
+++ b/src/main/java/com/gorogoro/auth/user/application/port/in/GetUserUseCase.java
@@ -1,11 +1,11 @@
 package com.gorogoro.auth.user.application.port.in;
 
+import com.gorogoro.auth.user.application.dto.result.UserNicknamesResult;
 import com.gorogoro.auth.user.application.dto.result.UserResult;
 
 import java.util.List;
-import java.util.Map;
 
 public interface GetUserUseCase {
     UserResult getUser(Long userId);
-    Map<Long, String> getUserNicknames(List<Long> userIds);
+    UserNicknamesResult getUserNicknames(List<Long> userIds);
 }

--- a/src/main/java/com/gorogoro/auth/user/application/port/in/GetUserUseCase.java
+++ b/src/main/java/com/gorogoro/auth/user/application/port/in/GetUserUseCase.java
@@ -2,6 +2,10 @@ package com.gorogoro.auth.user.application.port.in;
 
 import com.gorogoro.auth.user.application.dto.result.UserResult;
 
+import java.util.List;
+import java.util.Map;
+
 public interface GetUserUseCase {
     UserResult getUser(Long userId);
+    Map<Long, String> getUserNicknames(List<Long> userIds);
 }

--- a/src/main/java/com/gorogoro/auth/user/application/port/in/RegisterUseCase.java
+++ b/src/main/java/com/gorogoro/auth/user/application/port/in/RegisterUseCase.java
@@ -1,9 +1,0 @@
-package com.gorogoro.auth.user.application.port.in;
-
-import com.gorogoro.auth.user.application.dto.command.RegisterCommand;
-import com.gorogoro.auth.user.application.dto.result.RegisterResult;
-
-public interface RegisterUseCase {
-    RegisterResult register(RegisterCommand request);
-}
-

--- a/src/main/java/com/gorogoro/auth/user/application/port/out/UserQueryPort.java
+++ b/src/main/java/com/gorogoro/auth/user/application/port/out/UserQueryPort.java
@@ -2,10 +2,12 @@ package com.gorogoro.auth.user.application.port.out;
 
 import com.gorogoro.auth.user.domain.model.User;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserQueryPort {
     Optional<User> getUserByEmail(String email);
     Optional<User> getUserId(Long id);
+    List<User> getUsersByIds(List<Long> ids);
     boolean existsByEmail(String email);
 }

--- a/src/main/java/com/gorogoro/auth/user/application/service/UserService.java
+++ b/src/main/java/com/gorogoro/auth/user/application/service/UserService.java
@@ -18,6 +18,10 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -50,6 +54,22 @@ public class UserService implements RegisterUserUseCase, GetUserUseCase, UpdateU
         User user = userQueryPort.getUserId(userId)
                 .orElseThrow(() -> new BaseException(UserErrorCode.USER_NOT_FOUND));
         return UserResult.from(user);
+    }
+
+    @Override
+    public Map<Long, String> getUserNicknames(List<Long> userIds) {
+        List<Long> distinctUserIds = userIds.stream()
+                .distinct()
+                .toList();
+
+        List<User> users = userQueryPort.getUsersByIds(distinctUserIds);
+
+        if (users.size() != distinctUserIds.size()) {
+            throw new BaseException(UserErrorCode.USER_NOT_FOUND);
+        }
+
+        return users.stream()
+                .collect(Collectors.toMap(User::getId, User::getName));
     }
 
     @Override

--- a/src/main/java/com/gorogoro/auth/user/application/service/UserService.java
+++ b/src/main/java/com/gorogoro/auth/user/application/service/UserService.java
@@ -4,6 +4,7 @@ import com.gorogoro.auth.global.exception.BaseException;
 import com.gorogoro.auth.global.exception.code.UserErrorCode;
 import com.gorogoro.auth.user.application.dto.command.RegisterUserCommand;
 import com.gorogoro.auth.user.application.dto.command.UpdateUserCommand;
+import com.gorogoro.auth.user.application.dto.result.UserNicknamesResult;
 import com.gorogoro.auth.user.application.dto.result.UserResult;
 import com.gorogoro.auth.user.application.port.in.GetUserUseCase;
 import com.gorogoro.auth.user.application.port.in.RegisterUserUseCase;
@@ -57,19 +58,29 @@ public class UserService implements RegisterUserUseCase, GetUserUseCase, UpdateU
     }
 
     @Override
-    public Map<Long, String> getUserNicknames(List<Long> userIds) {
+    public UserNicknamesResult getUserNicknames(List<Long> userIds) {
         List<Long> distinctUserIds = userIds.stream()
                 .distinct()
                 .toList();
 
         List<User> users = userQueryPort.getUsersByIds(distinctUserIds);
 
-        if (users.size() != distinctUserIds.size()) {
-            throw new BaseException(UserErrorCode.USER_NOT_FOUND);
-        }
-
-        return users.stream()
+        // 3. 조회된 유저 Map 생성 (ID -> Nickname)
+        Map<Long, String> foundNicknames = users.stream()
                 .collect(Collectors.toMap(User::getId, User::getName));
+
+        // 4. 조회된 ID 목록 추출
+        List<Long> foundIds = users.stream()
+                .map(User::getId)
+                .toList();
+
+        // 5. 누락된 ID 계산 (요청 ID - 조회된 ID)
+        List<Long> missingIds = distinctUserIds.stream()
+                .filter(id -> !foundIds.contains(id))
+                .toList();
+
+        // 6. 결과 반환
+        return UserNicknamesResult.of(foundNicknames, missingIds);
     }
 
     @Override


### PR DESCRIPTION
[FEAT] 유저 닉네임 일괄 조회 API 구현

## ✨ 요약
타 서비스(서버) 간 통신 효율화를 위해 유저 ID 목록을 받아 닉네임을 일괄 조회하는 API를 구현했습니다.
존재하지 않는 ID가 포함될 경우, **조회된 유저의 닉네임 목록**과 **조회되지 않은(누락된) ID 목록**을 함께 반환하도록 개선했습니다.

**Response (200 OK - 2번 유저가 없는 경우)**
```JSON{
{
  "nicknames": {
    "1": "kim",
    "3": "lee"
  },
  "missingUserIds": [2]
}
```

## 📝 작업 내용
- **Controller (`ServerController`)**
  - `GET /server/users/nicknames` 엔드포인트 추가
  - 응답 타입을 UserNicknamesResponse`로 설정하여 조회 결과와 실패 목록을 분리하여 반환

- **Service (`UserService`)**
  - `getUserNicknames(List<Long> userIds)` 구현
  - 요청받은 ID 목록 중복 제거
  - **부분 성공 로직 적용**
    - DB에서 조회된 유저는 `nicknames` 맵에 담음
    - 요청했으나 조회되지 않은 ID는 `missingUserIds` 리스트에 담음

- **Port / UseCase**
  - `UserQueryPort`, `GetUserUseCase`에 일괄 조회 인터페이스 정의

## 💭 주의 사항

## 💡 리뷰 포인트
- `missingUserIds`를 계산하는 로직(`UserService`)이 정확한지 확인 부탁드립니다.
- 새로 추가된 DTO 구조(`Result`, `Response`)가 적절한지 검토 부탁드립니다.

## ✅ 테스트
- [x] 로컬 빌드/실행
- [ ] 단위 테스트 추가/통과
- [x] API 수동 테스트