### PR TITLE
[FEAT] 로그아웃 기능 구현

### DIFF
--- a/src/main/java/com/gorogoro/auth/authorization/adapter/in/web/AuthorizationController.java
+++ b/src/main/java/com/gorogoro/auth/authorization/adapter/in/web/AuthorizationController.java
@@ -6,7 +6,10 @@ import com.gorogoro.auth.authorization.adapter.in.web.response.ReissueResponse;
 import com.gorogoro.auth.authorization.application.dto.command.LoginCommand;
 import com.gorogoro.auth.authorization.application.dto.result.LoginResult;
 import com.gorogoro.auth.authorization.application.port.in.LoginUseCase;
+import com.gorogoro.auth.authorization.application.port.in.LogoutUseCase;
 import com.gorogoro.auth.authorization.application.port.in.ReissueUseCase;
+import com.gorogoro.auth.global.exception.BaseException;
+import com.gorogoro.auth.global.exception.code.AuthErrorCode;
 import com.gorogoro.auth.global.jwt.JwtConstants;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +17,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,6 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthorizationController {
     private final LoginUseCase loginUseCase;
     private final ReissueUseCase reissueUseCase;
+    private final LogoutUseCase logoutUseCase;
 
     @PostMapping("/login")
     public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
@@ -45,9 +50,28 @@ public class AuthorizationController {
     }
 
     @PostMapping("/reissue")
-    public ResponseEntity<ReissueResponse> reissue(@CookieValue(value = "refresh_token") String refreshToken) {
+    public ResponseEntity<ReissueResponse> reissue(@CookieValue(value = "refresh_token", required = false) String refreshToken) {
+        if (refreshToken == null) {
+            throw new BaseException(AuthErrorCode.INVALID_REFRESH_TOKEN);
+        }
         return ResponseEntity.ok(
                 ReissueResponse.from(reissueUseCase.reissue(refreshToken)));
+    }
+
+    @DeleteMapping("/logout")
+    public ResponseEntity<Void> logout(@CookieValue(value = "refresh_token", required = false) String refreshToken) {
+        logoutUseCase.logout(refreshToken);
+        ResponseCookie refreshTokenCookie = ResponseCookie.from("refresh_token", "")
+                .httpOnly(true)
+                .secure(false)
+                .path("/")
+                .maxAge(0)
+                .sameSite("Lax")
+                .build();
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
+                .build();
     }
 }
 

--- a/src/main/java/com/gorogoro/auth/authorization/adapter/in/web/AuthorizationController.java
+++ b/src/main/java/com/gorogoro/auth/authorization/adapter/in/web/AuthorizationController.java
@@ -58,7 +58,7 @@ public class AuthorizationController {
                 ReissueResponse.from(reissueUseCase.reissue(refreshToken)));
     }
 
-    @DeleteMapping("/logout")
+    @PostMapping("/logout")
     public ResponseEntity<Void> logout(@CookieValue(value = "refresh_token", required = false) String refreshToken) {
         logoutUseCase.logout(refreshToken);
         ResponseCookie refreshTokenCookie = ResponseCookie.from("refresh_token", "")

--- a/src/main/java/com/gorogoro/auth/authorization/adapter/out/persistence/adapter/AuthorizationPersistenceAdapter.java
+++ b/src/main/java/com/gorogoro/auth/authorization/adapter/out/persistence/adapter/AuthorizationPersistenceAdapter.java
@@ -28,5 +28,10 @@ public class AuthorizationPersistenceAdapter implements RefreshTokenQueryPort, R
         return refreshTokenRedisRepository.findById(token)
                 .map(refreshTokenMapper::toDomain);
     }
+
+    @Override
+    public void deleteRefreshToken(String refreshToken) {
+        refreshTokenRedisRepository.deleteById(refreshToken);
+    }
 }
 

--- a/src/main/java/com/gorogoro/auth/authorization/application/port/in/LogoutUseCase.java
+++ b/src/main/java/com/gorogoro/auth/authorization/application/port/in/LogoutUseCase.java
@@ -1,0 +1,5 @@
+package com.gorogoro.auth.authorization.application.port.in;
+
+public interface LogoutUseCase {
+    void logout(String refreshToken);
+}

--- a/src/main/java/com/gorogoro/auth/authorization/application/port/out/RefreshTokenCommandPort.java
+++ b/src/main/java/com/gorogoro/auth/authorization/application/port/out/RefreshTokenCommandPort.java
@@ -4,5 +4,6 @@ import com.gorogoro.auth.authorization.domain.model.RefreshToken;
 
 public interface RefreshTokenCommandPort {
     void saveRefreshToken(RefreshToken refreshToken);
+    void deleteRefreshToken(String refreshToken);
 }
 

--- a/src/main/java/com/gorogoro/auth/authorization/application/service/AuthorizationService.java
+++ b/src/main/java/com/gorogoro/auth/authorization/application/service/AuthorizationService.java
@@ -4,6 +4,7 @@ import com.gorogoro.auth.authorization.application.dto.command.LoginCommand;
 import com.gorogoro.auth.authorization.application.dto.result.LoginResult;
 import com.gorogoro.auth.authorization.application.dto.result.ReissueResult;
 import com.gorogoro.auth.authorization.application.port.in.LoginUseCase;
+import com.gorogoro.auth.authorization.application.port.in.LogoutUseCase;
 import com.gorogoro.auth.authorization.application.port.in.ReissueUseCase;
 import com.gorogoro.auth.authorization.application.port.out.RefreshTokenCommandPort;
 import com.gorogoro.auth.authorization.application.port.out.RefreshTokenQueryPort;
@@ -23,7 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
-public class AuthorizationService implements LoginUseCase, ReissueUseCase {
+public class AuthorizationService implements LoginUseCase, ReissueUseCase, LogoutUseCase {
     private final JwtProvider jwtProvider;
     private final PasswordEncoder passwordEncoder;
     private final UserQueryPort userQueryPort;
@@ -62,8 +63,8 @@ public class AuthorizationService implements LoginUseCase, ReissueUseCase {
         RefreshToken refreshToken = refreshTokenQueryPort.getRefreshToken(refreshTokenValue)
                 .orElseThrow(() -> new BaseException(AuthErrorCode.INVALID_REFRESH_TOKEN));
 
-        if (refreshToken.isExpired(System.currentTimeMillis())) {
-            throw new BaseException(AuthErrorCode.REFRESH_TOKEN_EXPIRED);
+        if (refreshToken == null) {
+            throw new BaseException(AuthErrorCode.INVALID_REFRESH_TOKEN);
         }
 
         // 사용자 정보 조회
@@ -73,6 +74,12 @@ public class AuthorizationService implements LoginUseCase, ReissueUseCase {
         // 새로운 Access Token 생성
         String newAccessToken = jwtProvider.generateAccessToken(user.getId(), String.valueOf(user.getRole()));
         return ReissueResult.of(newAccessToken);
+    }
+
+    @Override
+    @Transactional
+    public void logout(String refreshToken) {
+        refreshTokenCommandPort.deleteRefreshToken(refreshToken);
     }
 }
 

--- a/src/main/java/com/gorogoro/auth/global/config/SecurityConfig.java
+++ b/src/main/java/com/gorogoro/auth/global/config/SecurityConfig.java
@@ -35,6 +35,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/users/register").permitAll()
                         .requestMatchers("/api/auth/login").permitAll()
                         .requestMatchers("/api/auth/reissue").permitAll()
+                        .requestMatchers("/api/auth/logout").permitAll()
                         .requestMatchers("/actuator/**").permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/gorogoro/auth/user/application/service/UserService.java
+++ b/src/main/java/com/gorogoro/auth/user/application/service/UserService.java
@@ -12,7 +12,6 @@ import com.gorogoro.auth.user.application.port.in.UpdateUserUseCase;
 import com.gorogoro.auth.user.application.port.out.UserCommandPort;
 import com.gorogoro.auth.user.application.port.out.UserQueryPort;
 import com.gorogoro.auth.user.domain.model.User;
-import com.gorogoro.auth.user.domain.type.UserRole;
 import com.gorogoro.auth.user.domain.type.UserStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;


### PR DESCRIPTION
## ✨ 요약
Redis를 활용한 로그아웃 기능을 구현하여 리프레시 토큰을 삭제 및 만료 처리하고, 토큰 재발급 API 호출 시 쿠키가 없는 경우에 대한 예외 처리를 개선하여 클라이언트가 명확한 401 응답을 받을 수 있도록 수정했습니다.

## 📝 작업 내용
**1. 로그아웃 기능 구현**
- **Port/Adapter**: `RefreshTokenCommandPort`에 `deleteRefreshToken` 메서드를 추가하고, `AuthorizationPersistenceAdapter`에서 Redis 삭제 로직을 구현했습니다.
- **UseCase/Service**: `LogoutUseCase` 인터페이스를 생성하고 `AuthorizationService`에서 이를 구현했습니다.
- **Controller**: `/api/auth/logout` 엔드포인트를 추가했습니다.
    - Redis에서 리프레시 토큰 삭제
    - `ResponseCookie`를 사용하여 브라우저 쿠키(refresh_token) 즉시 만료 (Max-Age: 0)
- **Security**: `SecurityConfig`에 로그아웃 경로(`/api/auth/logout`)에 대한 접근 허용(`permitAll`)을 추가했습니다.

**2. 토큰 재발급(Reissue) 로직 개선**
- 쿠키가 없을 경우 명시적으로 `BaseException(AuthErrorCode.INVALID_REFRESH_TOKEN)`을 던지도록 수정하여, 일관된 포맷의 401 에러(Code: `ATH-0002`)를 반환하도록 개선했습니다.

## 💭 주의 사항
- 재발급 요청 시 쿠키가 없으면 기존에는 500 에러(MissingRequestCookieException)가 발생했으나, 이제는 401 에러가 발생합니다. 프론트엔드에서 401 응답 시 로그인 페이지로 리다이렉트 처리가 필요합니다.

## 💡 리뷰 포인트
- `AuthorizationController`의 `reissue` 메서드에서 `required = false` 설정과 `null` 체크 로직이 의도대로 동작하는지 확인 부탁드립니다.

## ✅ 테스트
- [x] 로컬 빌드/실행
- [ ] 단위 테스트 추가/통과
- [x] API 수동 테스트